### PR TITLE
Fix Windows compilation with Unicode enabled

### DIFF
--- a/tinydir.h
+++ b/tinydir.h
@@ -93,7 +93,7 @@ typedef struct
 	tinydir_file *_files;
 #ifdef _WIN32
 	HANDLE _h;
-	WIN32_FIND_DATA _f;
+	WIN32_FIND_DATAA _f;
 #else
 	DIR *_d;
 	struct dirent *_e;
@@ -153,7 +153,7 @@ int tinydir_open(tinydir_dir *dir, const char *path)
 	strcpy(dir->path, path);
 #ifdef _WIN32
 	strcat(dir->path, "\\*");
-	dir->_h = FindFirstFile(dir->path, &dir->_f);
+	dir->_h = FindFirstFileA(dir->path, &dir->_f);
 	dir->path[strlen(dir->path) - 2] = '\0';
 	if (dir->_h == INVALID_HANDLE_VALUE)
 #else
@@ -293,7 +293,7 @@ int tinydir_next(tinydir_dir *dir)
 	}
 
 #ifdef _WIN32
-	if (FindNextFile(dir->_h, &dir->_f) == 0)
+	if (FindNextFileA(dir->_h, &dir->_f) == 0)
 #else
 	dir->_e = readdir(dir->_d);
 	if (dir->_e == NULL)


### PR DESCRIPTION
`char*` is not compatible with wide char functions when Unicode is enabled. ANSI can be forced by adding an `A` at the end of the functions/types.