### PR TITLE
Adding clib support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "reader",
     "filesystem"
   ],
+  "src": [
+    "tinydir.h"
+  ],
   "version": "1.2.0",
   "repo": "cxong/tinydir"
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "src": [
     "tinydir.h"
   ],
-  "version": "1.2.0",
+  "version": "1.2",
   "repo": "cxong/tinydir"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "tinydir",
+  "description": "Lightweight, portable and easy to integrate C directory and file reader",
+  "license": "BSD-2-Clause",
+  "keywords": [
+    "dir",
+    "directory",
+    "file",
+    "reader",
+    "filesystem"
+  ],
+  "version": "1.2.0",
+  "repo": "cxong/tinydir"
+}


### PR DESCRIPTION
It'd be really useful if you could add [clib](https://github.com/clibs/clib) support for tinydir. It requires a `packge.json` to describe your package. Then it can be installed via `clib install`. As soon as you accept this PR I'll replace my fork with the original at the package list. https://github.com/clibs/clib/wiki/Packages

You can check with my fork by executing `clib install isty001/tinydir`