### PR TITLE
Fix build with gcc-6.

### DIFF
--- a/tests/util.c
+++ b/tests/util.c
@@ -3,6 +3,9 @@
 #ifdef _MSC_VER
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#else
+#include <stdlib.h>
+#include <unistd.h>
 #endif
 
 
@@ -20,8 +23,6 @@ void make_temp_file(const char *prefix, char *out)
 		fclose(fopen(out, "w"));
 	}
 #else
-	#include <stdlib.h>
-	#include <unistd.h>
 	sprintf(out, "%sXXXXXX", prefix);
 	close(mkstemp(out));
 #endif


### PR DESCRIPTION
Building the testsuite with gcc-6 fails with the following error:

```
In file included from /usr/include/endian.h:60:0,
                 from /usr/include/sys/types.h:216,
                 from /usr/include/stdlib.h:275,
                 from /home/besser82/rpmbuild/BUILD/tinydir-683d23031b42e29ec67590f93cc9b44630446311/tests/util.c:23:
/usr/include/bits/byteswap.h: In function 'make_temp_file':
/usr/include/bits/byteswap.h:45:1: error: invalid storage class for function '__bswap_32'
 __bswap_32 (unsigned int __bsx)
 ^~~~~~~~~~
/usr/include/bits/byteswap.h:109:1: error: invalid storage class for function '__bswap_64'
 __bswap_64 (__uint64_t __bsx)
 ^~~~~~~~~~
```
This small change fixes it.