### PR TITLE
Fixes FindFirstFile is missing on win10

### DIFF
--- a/tinydir.h
+++ b/tinydir.h
@@ -294,7 +294,7 @@ int tinydir_open(tinydir_dir *dir, const _tinydir_char_t *path)
 #ifdef _MSC_VER
 	_tinydir_strcpy(path_buf, dir->path);
 	_tinydir_strcat(path_buf, TINYDIR_STRING("\\*"));
-	dir->_h = FindFirstFile(path_buf, &dir->_f);
+	dir->_h = FindFirstFileEx(path_buf, FindExInfoStandard, &dir->_f, FindExSearchNameMatch, NULL, 0);
 	if (dir->_h == INVALID_HANDLE_VALUE)
 	{
 		errno = ENOENT;


### PR DESCRIPTION
Fixed issue: https://github.com/cxong/tinydir/issues/49