### PR TITLE
Fix FindFirstFile not available in Windows 10 SDK 10240 (#49)

### DIFF
--- a/tinydir.h
+++ b/tinydir.h
@@ -294,7 +294,11 @@ int tinydir_open(tinydir_dir *dir, const _tinydir_char_t *path)
 #ifdef _MSC_VER
 	_tinydir_strcpy(path_buf, dir->path);
 	_tinydir_strcat(path_buf, TINYDIR_STRING("\\*"));
+#if (defined WINAPI_FAMILY) && (WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
 	dir->_h = FindFirstFileEx(path_buf, FindExInfoStandard, &dir->_f, FindExSearchNameMatch, NULL, 0);
+#else
+	dir->_h = FindFirstFile(path_buf, &dir->_f);
+#endif
 	if (dir->_h == INVALID_HANDLE_VALUE)
 	{
 		errno = ENOENT;


### PR DESCRIPTION
This would be a better fix since it won't drop the support of Windows 95/98.

Test passed in Windows 7 + Visual Studio 2015 both in a UWP project (using SDK 10240) and a Win32 project.