### PR TITLE
tinydir_readfile(): avoid GCC 8+ warning and simplify

### DIFF
--- a/tinydir.h
+++ b/tinydir.h
@@ -498,6 +498,7 @@ int tinydir_next(tinydir_dir *dir)
 _TINYDIR_FUNC
 int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 {
+	const _tinydir_char_t *filename;
 	if (dir == NULL || file == NULL)
 	{
 		errno = EINVAL;
@@ -512,27 +513,21 @@ int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 		errno = ENOENT;
 		return -1;
 	}
-	if (_tinydir_strlen(dir->path) +
-		_tinydir_strlen(
+	filename =
 #ifdef _MSC_VER
-			dir->_f.cFileName
+		dir->_f.cFileName;
 #else
-			dir->_e->d_name
+		dir->_e->d_name;
 #endif
-		) + 1 + _TINYDIR_PATH_EXTRA >=
+	if (_tinydir_strlen(dir->path) +
+		_tinydir_strlen(filename) + 1 + _TINYDIR_PATH_EXTRA >=
 		_TINYDIR_PATH_MAX)
 	{
 		/* the path for the file will be too long */
 		errno = ENAMETOOLONG;
 		return -1;
 	}
-	if (_tinydir_strlen(
-#ifdef _MSC_VER
-			dir->_f.cFileName
-#else
-			dir->_e->d_name
-#endif
-		) >= _TINYDIR_FILENAME_MAX)
+	if (_tinydir_strlen(filename) >= _TINYDIR_FILENAME_MAX)
 	{
 		errno = ENAMETOOLONG;
 		return -1;
@@ -540,14 +535,8 @@ int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 
 	_tinydir_strcpy(file->path, dir->path);
 	_tinydir_strcat(file->path, TINYDIR_STRING("/"));
-	_tinydir_strcpy(file->name,
-#ifdef _MSC_VER
-		dir->_f.cFileName
-#else
-		dir->_e->d_name
-#endif
-	);
-	_tinydir_strcat(file->path, file->name);
+	_tinydir_strcpy(file->name, filename);
+	_tinydir_strcat(file->path, filename);
 #ifndef _MSC_VER
 #ifdef __MINGW32__
 	if (_tstat(


### PR DESCRIPTION
Hello,
thanks for your work on tinydir.
I'd like to avoid a warning from GCC. The code is correct, but the line

    _tinydir_strcat(file->path, file->name);

triggers the following warning on GCC 8 and 9 with optimization -O2 or -O3:
```
$ g++-8 -O2 -Wall -I.. file_open_sample.c
In file included from /usr/include/string.h:494,
                 from ../tinydir.h:46,
                 from file_open_sample.c:2:
In function ‘char* strcat(char*, const char*)’,
    inlined from ‘int tinydir_readfile(const tinydir_dir*, tinydir_file*)’ at ../tinydir.h:550:17,
    inlined from ‘int tinydir_file_open(tinydir_file*, const char*)’ at ../tinydir.h:727:23,
    inlined from ‘int main(int, char**)’ at file_open_sample.c:12:23:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:128:33: warning: ‘char* __builtin___strcat_chk(char*, const char*, long unsigned int)’ accessing 4097 or more bytes at offsets 0 and 4096 may overlap 1 byte at offset 4096 [-Wrestrict]
   return __builtin___strcat_chk (__dest, __src, __bos (__dest));
          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
As a workaround I added a local variable. It allows also to avoid repeating ifdefs.