### PR TITLE
Use lstat() for macOS and *BSD (bug fix)

### DIFF
--- a/tinydir.h
+++ b/tinydir.h
@@ -543,7 +543,9 @@ int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 	if (_tstat(
 #elif (defined _BSD_SOURCE) || (defined _DEFAULT_SOURCE)	\
 	|| ((defined _XOPEN_SOURCE) && (_XOPEN_SOURCE >= 500))	\
-	|| ((defined _POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L))
+	|| ((defined _POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L)) \
+	|| ((defined __APPLE__) && (defined __MACH__)) \
+	|| (defined BSD)
 	if (lstat(
 #else
 	if (stat(


### PR DESCRIPTION
Refer to issue #63. Thanks to @wojdyr.