### PR TITLE
Coerce size()/strlen() to unsigned int

### DIFF
--- a/tests/cbehave/rlutil/rlutil.h
+++ b/tests/cbehave/rlutil/rlutil.h
@@ -570,10 +570,10 @@ RLUTIL_INLINE void locate(int x, int y) {
 #ifdef __cplusplus
 RLUTIL_INLINE void setString(const RLUTIL_STRING_T & str_) {
 	const char * const str = str_.data();
-	unsigned int len = str_.size();
+	unsigned int len = static_cast<unsigned int>(str_.size());
 #else // __cplusplus
 RLUTIL_INLINE void setString(RLUTIL_STRING_T str) {
-	unsigned int len = strlen(str);
+	unsigned int len = (unsigned int)strlen(str);
 #endif // __cplusplus
 #if defined(_WIN32) && !defined(RLUTIL_USE_ANSI)
 	HANDLE hConsoleOutput = GetStdHandle(STD_OUTPUT_HANDLE);


### PR DESCRIPTION
Explicitly truncate string size to 32 bits to prevent C4267 on Visual Studio:

warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int'