### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ tinydir_close(&dir);
 
 ```C
 tinydir_dir dir;
-int i;
+size_t i;
 tinydir_open_sorted(&dir, "/path/to/dir");
 
 for (i = 0; i < dir.n_files; i++)


### PR DESCRIPTION
Both `n_files` and `tinydir_readfile_n` operate on indexes of type `size_t`. Additionally, compiling a test like the edited inline block, with stricter warnings, will fail.